### PR TITLE
Add support for build-time environment variables

### DIFF
--- a/pipeline/buildpacks/0.1/README.md
+++ b/pipeline/buildpacks/0.1/README.md
@@ -16,7 +16,7 @@ This pipeline builds source into a container image using [Cloud Native Buildpack
 ## Compatibility
 
 - **Tekton** v0.12.1 and above
-- **[Platform API][platform-api]** 
+- **[Platform API][platform-api]** 0.3
 
 [platform-api]: https://buildpacks.io/docs/reference/spec/platform-api/
 
@@ -39,6 +39,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/pipel
  - **`SOURCE_URL`**: A git repo url where the source code resides. _(REQUIRED)_
  - **`SOURCE_REFERENCE`**: The branch, tag or SHA to checkout. _(optional, default: "")_
  - **`SOURCE_SUBPATH`**: A subpath within checked out source where the source to build is located. _(optional, default: "")_
+ - **`ENV_VARS`**: Environment variables to set during _build-time_. _(optional, default: "[]")_
  - **`PROCESS_TYPE`**: The default process type to set on the image. _(optional, default: "web")_
  - **`RUN_IMAGE`**: The name of the run image to use (defaults to image specified in builder). _(optional, default: "")_
  - **`CACHE_IMAGE`**: The name of the persistent cache image. _(optional, default: "")_
@@ -50,8 +51,8 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/pipel
 The following is only a subset of [builders](https://buildpacks.io/docs/concepts/components/builder/) available. These are the suggested builders from the Cloud Native Buildpacks projects.
 
  - **`gcr.io/buildpacks/builder:v1`**: Ubuntu 18 base image with buildpacks for .NET, Go, Java, Node.js, and Python
- - **`heroku/buildpacks:18`**
- - **`heroku/buildpacks:20`**
+ - **`heroku/buildpacks:18`**: Base builder for Heroku-18 stack, based on ubuntu:18.04 base image
+ - **`heroku/buildpacks:20`**: Base builder for Heroku-20 stack, based on ubuntu:20.04 base image
  - **`paketobuildpacks/builder:base`**: Ubuntu bionic base image with buildpacks for Java, .NET Core, NodeJS, Go, Ruby, NGINX and Procfile
  - **`paketobuildpacks/builder:full`**: Ubuntu bionic base image with buildpacks for Java, .NET Core, NodeJS, Go, PHP, Ruby, Apache HTTPD, NGINX and Procfile
  - **`paketobuildpacks/builder:tiny`**: Tiny base image (bionic build image, distroless-like run image) with buildpacks for Java Native Image and Go

--- a/pipeline/buildpacks/0.1/README.md
+++ b/pipeline/buildpacks/0.1/README.md
@@ -16,7 +16,7 @@ This pipeline builds source into a container image using [Cloud Native Buildpack
 ## Compatibility
 
 - **Tekton** v0.12.1 and above
-- **[Platform API][platform-api]** 0.3
+- **[Platform API][platform-api]** 
 
 [platform-api]: https://buildpacks.io/docs/reference/spec/platform-api/
 
@@ -39,7 +39,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/pipel
  - **`SOURCE_URL`**: A git repo url where the source code resides. _(REQUIRED)_
  - **`SOURCE_REFERENCE`**: The branch, tag or SHA to checkout. _(optional, default: "")_
  - **`SOURCE_SUBPATH`**: A subpath within checked out source where the source to build is located. _(optional, default: "")_
- - **`ENV_VARS`**: Environment variables to set during _build-time_. _(optional, default: "[]")_
+ - **`ENV_VARS`**: Environment variables to set during _build-time_. _(optional, default: [])_
  - **`PROCESS_TYPE`**: The default process type to set on the image. _(optional, default: "web")_
  - **`RUN_IMAGE`**: The name of the run image to use (defaults to image specified in builder). _(optional, default: "")_
  - **`CACHE_IMAGE`**: The name of the persistent cache image. _(optional, default: "")_

--- a/pipeline/buildpacks/0.1/buildpacks.yaml
+++ b/pipeline/buildpacks/0.1/buildpacks.yaml
@@ -35,6 +35,10 @@ spec:
     - name: SOURCE_SUBPATH
       description: A subpath within checked out source where the source to build is located.
       default: ""
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
     - name: PROCESS_TYPE
       description: The default process type to set on the image.
       default: "web"
@@ -86,6 +90,8 @@ spec:
           value: "$(params.SOURCE_SUBPATH)"
         - name: PROCESS_TYPE
           value: "$(params.PROCESS_TYPE)"
+        - name: ENV_VARS
+          value: ["$(params.ENV_VARS)"]
         - name: RUN_IMAGE
           value: "$(params.RUN_IMAGE)"
         - name: CACHE_IMAGE
@@ -115,6 +121,8 @@ spec:
           value: "$(params.APP_IMAGE)"
         - name: SOURCE_SUBPATH
           value: "$(params.SOURCE_SUBPATH)"
+        - name: ENV_VARS
+          value: ["$(params.ENV_VARS)"]
         - name: PROCESS_TYPE
           value: "$(params.PROCESS_TYPE)"
         - name: RUN_IMAGE

--- a/pipeline/buildpacks/0.1/samples/env-vars.yaml
+++ b/pipeline/buildpacks/0.1/samples/env-vars.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: env-var-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: env-var-pipelinerun
+spec:
+  pipelineRef:
+    name: buildpacks
+  params:
+    - name: BUILDER_IMAGE
+      value: docker.io/cnbs/sample-builder:bionic@sha256:6c03dd604503b59820fd15adbc65c0a077a47e31d404a3dcad190f3179e920b5
+    - name: TRUST_BUILDER
+      value: "true"
+    - name: APP_IMAGE
+      value: <IMAGE_NAME>
+    - name: SOURCE_URL
+      value: https://github.com/buildpacks/samples
+    - name: SOURCE_SUBPATH
+      value: apps
+    - name: PROCESS_TYPE
+      value: ""
+    - name: ENV_VARS
+      value:
+        - "ENV_VAR_1=VALUE_1"
+        - "ENV_VAR_2=VALUE 2"
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: env-var-ws-pvc
+    # NOTE: Pipeline hangs if optional cache workspace is missing so we provide an empty directory
+    - name: cache-ws
+      emptyDir: {}
+---

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -55,7 +55,7 @@ echo "> Extracting workspaces..."
 export WORKSPACES=$(cat "$DEFINITION" | yj | jq -r '.spec.workspaces[] | . + {"note": (if .optional then "_(optional)_" else "_(REQUIRED)_" end) } | " - **`\(.name)`**: \(.description) \(.note)"')
 
 echo "> Extracting parameters..."
-export PARAMETERS=$(cat "$DEFINITION" | yj | jq -r '.spec.params[] | . + {"note": (if .default then "_(optional, default: \"\(.default)\")_" else "_(REQUIRED)_" end) } | " - **`\(.name)`**: \(.description) \(.note)"')
+export PARAMETERS=$(cat "$DEFINITION" | yj | jq -r '.spec.params[] | . + {"default": (if .default and .type != "array" then "\"\(.default)\"" else .default end) } | . + {"note": (if .default then "_(optional, default: \(.default))_" else "_(REQUIRED)_" end) } | " - **`\(.name)`**: \(.description) \(.note)"')
 
 echo "> Extracting metadata..."
 export TEKTON_MIN_VERSION=$(cat "$DEFINITION" | yj | jq -r '.metadata.annotations["tekton.dev/pipelines.minVersion"]')

--- a/task/buildpacks-phases/0.2/README.md
+++ b/task/buildpacks-phases/0.2/README.md
@@ -33,7 +33,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
  - **`APP_IMAGE`**: The name of where to store the app image. _(REQUIRED)_
  - **`BUILDER_IMAGE`**: The image on which builds will run (must include lifecycle and compatible buildpacks). _(REQUIRED)_
  - **`SOURCE_SUBPATH`**: A subpath within the `source` input where the source to build is located. _(optional, default: "")_
- - **`ENV_VARS`**: Environment variables to set during _build-time_. _(optional, default: "[]")_
+ - **`ENV_VARS`**: Environment variables to set during _build-time_. _(optional, default: [])_
  - **`PROCESS_TYPE`**: The default process type to set on the image. _(optional, default: "web")_
  - **`RUN_IMAGE`**: Reference to a run image to use. _(optional, default: "")_
  - **`CACHE_IMAGE`**: The name of the persistent app cache image (if no cache workspace is provided). _(optional, default: "")_

--- a/task/buildpacks-phases/0.2/README.md
+++ b/task/buildpacks-phases/0.2/README.md
@@ -33,6 +33,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
  - **`APP_IMAGE`**: The name of where to store the app image. _(REQUIRED)_
  - **`BUILDER_IMAGE`**: The image on which builds will run (must include lifecycle and compatible buildpacks). _(REQUIRED)_
  - **`SOURCE_SUBPATH`**: A subpath within the `source` input where the source to build is located. _(optional, default: "")_
+ - **`ENV_VARS`**: Environment variables to set during _build-time_. _(optional, default: "[]")_
  - **`PROCESS_TYPE`**: The default process type to set on the image. _(optional, default: "web")_
  - **`RUN_IMAGE`**: Reference to a run image to use. _(optional, default: "")_
  - **`CACHE_IMAGE`**: The name of the persistent app cache image (if no cache workspace is provided). _(optional, default: "")_
@@ -46,8 +47,8 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 The following is only a subset of [builders](https://buildpacks.io/docs/concepts/components/builder/) available. These are the suggested builders from the Cloud Native Buildpacks projects.
 
  - **`gcr.io/buildpacks/builder:v1`**: Ubuntu 18 base image with buildpacks for .NET, Go, Java, Node.js, and Python
- - **`heroku/buildpacks:18`**
- - **`heroku/buildpacks:20`**
+ - **`heroku/buildpacks:18`**: Base builder for Heroku-18 stack, based on ubuntu:18.04 base image
+ - **`heroku/buildpacks:20`**: Base builder for Heroku-20 stack, based on ubuntu:20.04 base image
  - **`paketobuildpacks/builder:base`**: Ubuntu bionic base image with buildpacks for Java, .NET Core, NodeJS, Go, Ruby, NGINX and Procfile
  - **`paketobuildpacks/builder:full`**: Ubuntu bionic base image with buildpacks for Java, .NET Core, NodeJS, Go, PHP, Ruby, Apache HTTPD, NGINX and Procfile
  - **`paketobuildpacks/builder:tiny`**: Tiny base image (bionic build image, distroless-like run image) with buildpacks for Java Native Image and Go
@@ -56,6 +57,7 @@ The following is only a subset of [builders](https://buildpacks.io/docs/concepts
 
 See the following samples for usage:
 
+- **[env-vars](samples/env-vars.yaml)**: A Pipeline configured to provide _build-time_ environment variables.
 - **[lifecycle-image](samples/lifecycle-image.yaml)**: A Pipeline configured to use a specific image of the lifecycle.
 
 ## Previous Versions

--- a/task/buildpacks-phases/0.2/README.tpl.md
+++ b/task/buildpacks-phases/0.2/README.tpl.md
@@ -36,6 +36,7 @@ ${BUILDERS}
 
 See the following samples for usage:
 
+- **[env-vars](samples/env-vars.yaml)**: A Pipeline configured to provide _build-time_ environment variables.
 - **[lifecycle-image](samples/lifecycle-image.yaml)**: A Pipeline configured to use a specific image of the lifecycle.
 
 ## Previous Versions

--- a/task/buildpacks-phases/0.2/buildpacks-phases.yaml
+++ b/task/buildpacks-phases/0.2/buildpacks-phases.yaml
@@ -30,6 +30,10 @@ spec:
     - name: SOURCE_SUBPATH
       description: A subpath within the `source` input where the source to build is located.
       default: ""
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
     - name: PROCESS_TYPE
       description: The default process type to set on the image.
       default: "web"
@@ -60,6 +64,9 @@ spec:
   steps:
     - name: prepare
       image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      args:
+        - "--env-vars"
+        - "$(params.ENV_VARS[*])"
       script: |
         #!/usr/bin/env bash
         set -e
@@ -72,10 +79,39 @@ spec:
         for path in "/tekton/home" "/layers" "$(workspaces.source.path)"; do
           echo "> Setting permissions on '$path'..."
           chown -R "$(params.USER_ID):$(params.GROUP_ID)" "$path"
-        done 
+        done
+
+        echo "> Parsing additional configuration..."
+        parsing_flag=""
+        envs=()
+        for arg in "$@"; do
+            if [[ "$arg" == "--env-vars" ]]; then
+                echo "-> Parsing env variables..."
+                parsing_flag="env-vars"
+            elif [[ "$parsing_flag" == "env-vars" ]]; then
+                envs+=("$arg")
+            fi
+        done
+
+        echo "> Processing any environment variables..."
+        ENV_DIR="/platform/env"
+
+        echo "--> Creating 'env' directory: $ENV_DIR"
+        mkdir -p "$ENV_DIR"
+
+        for env in "${envs[@]}"; do
+            IFS='=' read -r key value string <<< "$env"
+            if [[ "$key" != "" && "$value" != "" ]]; then
+                path="${ENV_DIR}/${key}"
+                echo "--> Writing ${path}..."
+                echo -n "$value" > "$path"
+            fi
+        done
       volumeMounts:
         - name: layers-dir
           mountPath: /layers
+        - name: $(params.PLATFORM_DIR)
+          mountPath: /platform
       securityContext:
         privileged: true
 

--- a/task/buildpacks-phases/0.2/samples/env-vars.yaml
+++ b/task/buildpacks-phases/0.2/samples/env-vars.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: env-vars-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: env-vars-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: source-ws
+      - name: cache-ws
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: source-ws
+        params:
+          - name: url
+            value: https://github.com/buildpacks/samples
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+      - name: buildpacks
+        taskRef:
+          name: buildpacks-phases
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: source-ws
+          - name: cache
+            workspace: cache-ws
+        params:
+          - name: APP_IMAGE
+            value: <IMAGE_NAME>
+          - name: SOURCE_SUBPATH
+            value: apps
+          - name: BUILDER_IMAGE
+            value: docker.io/cnbs/sample-builder:alpine@sha256:b51367258b3b6fff1fe8f375ecca79dab4339b177efb791e131417a5a4357f42
+          - name: ENV_VARS
+            value:
+              - "ENV_VAR_1=VALUE_1"
+              - "ENV_VAR_2=VALUE 2"
+          - name: PROCESS_TYPE
+            value: ""
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: env-vars-ws-pvc
+    - name: cache-ws
+      subPath: cache
+      persistentVolumeClaim:
+        claimName: env-vars-ws-pvc
+---

--- a/task/buildpacks/0.3/README.md
+++ b/task/buildpacks/0.3/README.md
@@ -31,7 +31,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
  - **`APP_IMAGE`**: The name of where to store the app image. _(REQUIRED)_
  - **`BUILDER_IMAGE`**: The image on which builds will run (must include lifecycle and compatible buildpacks). _(REQUIRED)_
  - **`SOURCE_SUBPATH`**: A subpath within the `source` input where the source to build is located. _(optional, default: "")_
- - **`ENV_VARS`**: Environment variables to set during _build-time_. _(optional, default: "[]")_
+ - **`ENV_VARS`**: Environment variables to set during _build-time_. _(optional, default: [])_
  - **`PROCESS_TYPE`**: The default process type to set on the image. _(optional, default: "web")_
  - **`RUN_IMAGE`**: Reference to a run image to use. _(optional, default: "")_
  - **`CACHE_IMAGE`**: The name of the persistent app cache image (if no cache workspace is provided). _(optional, default: "")_

--- a/task/buildpacks/0.3/README.md
+++ b/task/buildpacks/0.3/README.md
@@ -31,6 +31,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
  - **`APP_IMAGE`**: The name of where to store the app image. _(REQUIRED)_
  - **`BUILDER_IMAGE`**: The image on which builds will run (must include lifecycle and compatible buildpacks). _(REQUIRED)_
  - **`SOURCE_SUBPATH`**: A subpath within the `source` input where the source to build is located. _(optional, default: "")_
+ - **`ENV_VARS`**: Environment variables to set during _build-time_. _(optional, default: "[]")_
  - **`PROCESS_TYPE`**: The default process type to set on the image. _(optional, default: "web")_
  - **`RUN_IMAGE`**: Reference to a run image to use. _(optional, default: "")_
  - **`CACHE_IMAGE`**: The name of the persistent app cache image (if no cache workspace is provided). _(optional, default: "")_
@@ -44,11 +45,18 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 The following is only a subset of [builders](https://buildpacks.io/docs/concepts/components/builder/) available. These are the suggested builders from the Cloud Native Buildpacks projects.
 
  - **`gcr.io/buildpacks/builder:v1`**: Ubuntu 18 base image with buildpacks for .NET, Go, Java, Node.js, and Python
- - **`heroku/buildpacks:18`**
- - **`heroku/buildpacks:20`**
+ - **`heroku/buildpacks:18`**: Base builder for Heroku-18 stack, based on ubuntu:18.04 base image
+ - **`heroku/buildpacks:20`**: Base builder for Heroku-20 stack, based on ubuntu:20.04 base image
  - **`paketobuildpacks/builder:base`**: Ubuntu bionic base image with buildpacks for Java, .NET Core, NodeJS, Go, Ruby, NGINX and Procfile
  - **`paketobuildpacks/builder:full`**: Ubuntu bionic base image with buildpacks for Java, .NET Core, NodeJS, Go, PHP, Ruby, Apache HTTPD, NGINX and Procfile
  - **`paketobuildpacks/builder:tiny`**: Tiny base image (bionic build image, distroless-like run image) with buildpacks for Java Native Image and Go
+
+
+## Usage
+
+See the following samples for usage:
+
+- **[env-vars](samples/env-vars.yaml)**: A Pipeline configured to provide _build-time_ environment variables.
 
 ## Previous Versions
 

--- a/task/buildpacks/0.3/README.tpl.md
+++ b/task/buildpacks/0.3/README.tpl.md
@@ -30,6 +30,13 @@ The following is only a subset of [builders](https://buildpacks.io/docs/concepts
 
 ${BUILDERS}
 
+
+## Usage
+
+See the following samples for usage:
+
+- **[env-vars](samples/env-vars.yaml)**: A Pipeline configured to provide _build-time_ environment variables.
+
 ## Previous Versions
 
 For support of previous [Platform API][platform-api]s use a previous version of this task.

--- a/task/buildpacks/0.3/buildpacks.yaml
+++ b/task/buildpacks/0.3/buildpacks.yaml
@@ -29,6 +29,10 @@ spec:
     - name: SOURCE_SUBPATH
       description: A subpath within the `source` input where the source to build is located.
       default: ""
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
     - name: PROCESS_TYPE
       description: The default process type to set on the image.
       default: "web"
@@ -59,6 +63,9 @@ spec:
   steps:
     - name: prepare
       image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      args:
+        - "--env-vars"
+        - "$(params.ENV_VARS[*])"
       script: |
         #!/usr/bin/env bash
         set -e
@@ -71,10 +78,39 @@ spec:
         for path in "/tekton/home" "/layers" "$(workspaces.source.path)"; do
           echo "> Setting permissions on '$path'..."
           chown -R "$(params.USER_ID):$(params.GROUP_ID)" "$path"
-        done 
+        done
+
+        echo "> Parsing additional configuration..."
+        parsing_flag=""
+        envs=()
+        for arg in "$@"; do
+            if [[ "$arg" == "--env-vars" ]]; then
+                echo "-> Parsing env variables..."
+                parsing_flag="env-vars"
+            elif [[ "$parsing_flag" == "env-vars" ]]; then
+                envs+=("$arg")
+            fi
+        done
+
+        echo "> Processing any environment variables..."
+        ENV_DIR="/platform/env"
+
+        echo "--> Creating 'env' directory: $ENV_DIR"
+        mkdir -p "$ENV_DIR"
+
+        for env in "${envs[@]}"; do
+            IFS='=' read -r key value string <<< "$env"
+            if [[ "$key" != "" && "$value" != "" ]]; then
+                path="${ENV_DIR}/${key}"
+                echo "--> Writing ${path}..."
+                echo -n "$value" > "$path"
+            fi
+        done
       volumeMounts:
         - name: layers-dir
           mountPath: /layers
+        - name: $(params.PLATFORM_DIR)
+          mountPath: /platform
       securityContext:
         privileged: true
 

--- a/task/buildpacks/0.3/samples/env-vars.yaml
+++ b/task/buildpacks/0.3/samples/env-vars.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: env-vars-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: env-vars-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: source-ws
+      - name: cache-ws
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: source-ws
+        params:
+          - name: url
+            value: https://github.com/buildpacks/samples
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+      - name: buildpacks
+        taskRef:
+          name: buildpacks
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: source-ws
+          - name: cache
+            workspace: cache-ws
+        params:
+          - name: APP_IMAGE
+            value: <IMAGE_NAME>
+          - name: SOURCE_SUBPATH
+            value: apps
+          - name: BUILDER_IMAGE
+            value: docker.io/cnbs/sample-builder:alpine@sha256:b51367258b3b6fff1fe8f375ecca79dab4339b177efb791e131417a5a4357f42
+          - name: ENV_VARS
+            value:
+              - "ENV_VAR_1=VALUE_1"
+              - "ENV_VAR_2=VALUE 2"
+          - name: PROCESS_TYPE
+            value: ""
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: env-vars-ws-pvc
+    - name: cache-ws
+      subPath: cache
+      persistentVolumeClaim:
+        claimName: env-vars-ws-pvc
+---


### PR DESCRIPTION
A new parameter `ENV_VARS` of type array is now available on the buildpacks
pipeline, buildpacks task, and buildpacks-phases task.

This feature primarily allows for users to provide environment variables
to buildpacks for configuration purposes.

Resolves #5 