### PR TITLE
Update buildpacks pipeline to work with Tekton Pipeline v0.36.0

### DIFF
--- a/pipeline/buildpacks/0.2/README.md
+++ b/pipeline/buildpacks/0.2/README.md
@@ -1,0 +1,100 @@
+<!-- NOTE: This file is auto-generated. Update via pipeline/buildpacks/0.1/README.tpl.md -->
+# Buildpacks
+
+This pipeline builds source into a container image using [Cloud Native Buildpacks](https://buildpacks.io). To do that, it uses [builders](https://buildpacks.io/docs/concepts/components/builder/#what-is-a-builder) to run buildpacks against your application source.
+
+> _**What are Cloud Native Buildpacks?**_
+> 
+> _Cloud Native Buildpacks are pluggable, modular tools that transform application source code into OCI images. They replace Dockerfiles in the app development lifecycle, and enable for swift rebasing of images and modular control over images (through the use of builders), among other benefits._
+
+## Dependencies
+
+- [`git-clone` task](https://github.com/tektoncd/catalog/tree/master/task/git-clone) 0.3 or newer
+- [`buildpacks` task](https://github.com/buildpacks/tekton-integration/tree/main/task/buildpacks/) 0.3 or newer
+- [`buildpacks-phases` task](https://github.com/buildpacks/tekton-integration/tree/main/task/buildpacks-phases/) 0.2 or newer
+
+## Compatibility
+
+- **Tekton** v0.17.0 and above
+- **[Platform API][platform-api]** 0.4
+
+[platform-api]: https://buildpacks.io/docs/reference/spec/platform-api/
+
+## Install
+
+#### Install dependencies (if missing)
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-clone.yaml
+kubectl apply -f https://raw.githubusercontent.com/buildpacks/tekton-integration/main/task/buildpacks/0.3/buildpacks.yaml
+kubectl apply -f https://raw.githubusercontent.com/buildpacks/tekton-integration/main/task/buildpacks-phases/0.2/buildpacks-phases.yaml
+```
+
+#### Install pipeline
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/buildpacks/tekton-integration/main/pipeline/buildpacks/0.1/buildpacks.yaml
+```
+
+## Workspaces
+
+ - **`source-ws`**: Location where source is stored. _(REQUIRED)_
+ - **`cache-ws`**: Location where cache is stored if CACHE_IMAGE is not provided. _(optional)_
+
+## Parameters
+
+ - **`BUILDER_IMAGE`**: The image on which builds will run (must include lifecycle and compatible buildpacks). _(REQUIRED)_
+ - **`TRUST_BUILDER`**: Whether the builder image is trusted. When false, each build phase is executed in isolation and credentials are only shared with trusted images. _(optional, default: "false")_
+ - **`APP_IMAGE`**: The name of where to store the app image. _(REQUIRED)_
+ - **`SOURCE_URL`**: A git repo url where the source code resides. _(REQUIRED)_
+ - **`SOURCE_REFERENCE`**: The branch, tag or SHA to checkout. _(optional, default: "")_
+ - **`SOURCE_SUBPATH`**: A subpath within checked out source where the source to build is located. _(optional, default: "")_
+ - **`ENV_VARS`**: Environment variables to set during _build-time_. _(optional, default: [])_
+ - **`PROCESS_TYPE`**: The default process type to set on the image. _(optional, default: "web")_
+ - **`RUN_IMAGE`**: The name of the run image to use (defaults to image specified in builder). _(optional, default: "")_
+ - **`CACHE_IMAGE`**: The name of the persistent cache image. _(optional, default: "")_
+ - **`USER_ID`**: The user ID of the builder image user. _(optional, default: "1000")_
+ - **`GROUP_ID`**: The group ID of the builder image user. _(optional, default: "1000")_
+
+## Builders
+
+_The following are the suggested [builders][builders] from the [Cloud Native Buildpacks][buildpacks-io] project. This is only a subset of builders available._
+
+ - **`gcr.io/buildpacks/builder:v1`**: Ubuntu 18 base image with buildpacks for .NET, Go, Java, Node.js, and Python
+ - **`heroku/buildpacks:18`**: Base builder for Heroku-18 stack, based on ubuntu:18.04 base image
+ - **`heroku/buildpacks:20`**: Base builder for Heroku-20 stack, based on ubuntu:20.04 base image
+ - **`paketobuildpacks/builder:base`**: Ubuntu bionic base image with buildpacks for Java, .NET Core, NodeJS, Go, Ruby, NGINX and Procfile
+ - **`paketobuildpacks/builder:full`**: Ubuntu bionic base image with buildpacks for Java, .NET Core, NodeJS, Go, PHP, Ruby, Apache HTTPD, NGINX and Procfile
+ - **`paketobuildpacks/builder:tiny`**: Tiny base image (bionic build image, distroless-like run image) with buildpacks for Java Native Image and Go
+
+[builders]: (https://buildpacks.io/docs/concepts/components/builder/)
+[buildpacks-io]: (https://buildpacks.io)
+
+## Usage
+
+See the following samples for usage:
+
+ - **[`cache-image.yaml`](samples/cache-image.yaml)**: A PipelineRun configured to cache build artifacts in an image.
+ - **[`cache-volume.yaml`](samples/cache-volume.yaml)**: A PipelineRun configured to cache build artifacts in a volume.
+ - **[`env-vars.yaml`](samples/env-vars.yaml)**: A PipelineRun configured to provide _build-time_ environment variables.
+ - **[`run-image.yaml`](samples/run-image.yaml)**: A PipelineRun configured to specify an explicit run image.
+
+## Support
+
+The [Buildpacks Community](http://buildpacks.io/community/) is always here to help. 
+
+We can be found in our [discussion board][discussion-board] or [slack][slack] (`#tekton`).
+
+[discussion-board]: https://github.com/buildpacks/community/discussions
+[slack]: https://slack.buildpacks.io
+
+## Contributing
+
+We ❤ contributions.
+
+This pipeline is maintained at [buildpacks/tekton-integration](https://github.com/buildpacks/tekton-integration). Issues, pull requests and other contributions can be made there. 
+
+To learn more, read the [CONTRIBUTING][contributing] and [DEVELOPMENT][development] documents.
+
+[contributing]: https://github.com/buildpacks/.github/blob/main/CONTRIBUTING.md
+[development]: https://github.com/buildpacks/tekton-integration/blob/main/DEVELOPMENT.md

--- a/pipeline/buildpacks/0.2/README.tpl.md
+++ b/pipeline/buildpacks/0.2/README.tpl.md
@@ -1,0 +1,56 @@
+# ${DISPLAY_NAME}
+
+${SUMMARY}
+
+## Dependencies
+
+- [`git-clone` task](https://github.com/tektoncd/catalog/tree/master/task/git-clone) 0.3 or newer
+- [`buildpacks` task](https://github.com/buildpacks/tekton-integration/tree/main/task/buildpacks/) 0.3 or newer
+- [`buildpacks-phases` task](https://github.com/buildpacks/tekton-integration/tree/main/task/buildpacks-phases/) 0.2 or newer
+
+## Compatibility
+
+- **Tekton** v${TEKTON_MIN_VERSION} and above
+- **[Platform API][platform-api]** ${PLATFORM_API_VERSION}
+
+[platform-api]: https://buildpacks.io/docs/reference/spec/platform-api/
+
+## Install
+
+#### Install dependencies (if missing)
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-clone.yaml
+kubectl apply -f https://raw.githubusercontent.com/buildpacks/tekton-integration/main/task/buildpacks/0.3/buildpacks.yaml
+kubectl apply -f https://raw.githubusercontent.com/buildpacks/tekton-integration/main/task/buildpacks-phases/0.2/buildpacks-phases.yaml
+```
+
+#### Install pipeline
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/buildpacks/tekton-integration/main/${TYPE}/${NAME}/${VERSION}/${NAME}.yaml
+```
+
+## Workspaces
+
+${WORKSPACES}
+
+## Parameters
+
+${PARAMETERS}
+
+## Builders
+
+${BUILDERS}
+
+## Usage
+
+${SAMPLES}
+
+## Support
+
+${SUPPORT}
+
+## Contributing
+
+${CONTRIBUTING}

--- a/pipeline/buildpacks/0.2/buildpacks.yaml
+++ b/pipeline/buildpacks/0.2/buildpacks.yaml
@@ -1,0 +1,140 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: buildpacks
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Image Build
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: image-build
+    tekton.dev/displayName: "Buildpacks"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    The Buildpacks pipeline builds source from a Git repository into a container image and pushes it to a registry, using Cloud Native Buildpacks.
+
+  workspaces:
+    - name: source-ws
+      description: Location where source is stored.
+    - name: cache-ws
+      description: Location where cache is stored if CACHE_IMAGE is not provided.
+      optional: true
+
+  params:
+    - name: BUILDER_IMAGE
+      description: The image on which builds will run (must include lifecycle and compatible buildpacks).
+    - name: TRUST_BUILDER
+      description: >-
+        Whether the builder image is trusted.
+        When false, each build phase is executed in isolation and credentials are only shared with trusted images.
+      default: "false"
+    - name: APP_IMAGE
+      description: The name of where to store the app image.
+    - name: SOURCE_URL
+      description: A git repo url where the source code resides.
+    - name: SOURCE_REFERENCE
+      description: The branch, tag or SHA to checkout.
+      default: ""
+    - name: SOURCE_SUBPATH
+      description: A subpath within checked out source where the source to build is located.
+      default: ""
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
+    - name: PROCESS_TYPE
+      description: The default process type to set on the image.
+      default: "web"
+    - name: RUN_IMAGE
+      description: The name of the run image to use (defaults to image specified in builder).
+      default: ""
+    - name: CACHE_IMAGE
+      description: The name of the persistent cache image.
+      default: ""
+    - name: USER_ID
+      description: The user ID of the builder image user.
+      default: "1000"
+    - name: GROUP_ID
+      description: The group ID of the builder image user.
+      default: "1000"
+
+  tasks:
+    - name: fetch-from-git
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: $(params.SOURCE_URL)
+        - name: revision
+          value: $(params.SOURCE_REFERENCE)
+      workspaces:
+        - name: output
+          workspace: source-ws
+    - name: build-trusted
+      runAfter:
+        - fetch-from-git
+      taskRef:
+        name: buildpacks
+      when:
+        - input: "$(params.TRUST_BUILDER)"
+          operator: in
+          values: ["true", "yes", "TRUE", "True"]
+      workspaces:
+        - name: source
+          workspace: source-ws
+        - name: cache
+          workspace: cache-ws
+      params:
+        - name: BUILDER_IMAGE
+          value: "$(params.BUILDER_IMAGE)"
+        - name: APP_IMAGE
+          value: "$(params.APP_IMAGE)"
+        - name: SOURCE_SUBPATH
+          value: "$(params.SOURCE_SUBPATH)"
+        - name: PROCESS_TYPE
+          value: "$(params.PROCESS_TYPE)"
+        - name: ENV_VARS
+          value: ["$(params.ENV_VARS)"]
+        - name: RUN_IMAGE
+          value: "$(params.RUN_IMAGE)"
+        - name: CACHE_IMAGE
+          value: "$(params.CACHE_IMAGE)"
+        - name: USER_ID
+          value: "$(params.USER_ID)"
+        - name: GROUP_ID
+          value: "$(params.GROUP_ID)"
+    - name: build-untrusted
+      runAfter:
+        - fetch-from-git
+      taskRef:
+        name: buildpacks-phases
+      when:
+        - input: "$(params.TRUST_BUILDER)"
+          operator: notin
+          values: ["true", "yes", "TRUE", "True"]
+      workspaces:
+        - name: source
+          workspace: source-ws
+        - name: cache
+          workspace: cache-ws
+      params:
+        - name: BUILDER_IMAGE
+          value: "$(params.BUILDER_IMAGE)"
+        - name: APP_IMAGE
+          value: "$(params.APP_IMAGE)"
+        - name: SOURCE_SUBPATH
+          value: "$(params.SOURCE_SUBPATH)"
+        - name: ENV_VARS
+          value: ["$(params.ENV_VARS)"]
+        - name: PROCESS_TYPE
+          value: "$(params.PROCESS_TYPE)"
+        - name: RUN_IMAGE
+          value: "$(params.RUN_IMAGE)"
+        - name: CACHE_IMAGE
+          value: "$(params.CACHE_IMAGE)"
+        - name: USER_ID
+          value: "$(params.USER_ID)"
+        - name: GROUP_ID
+          value: "$(params.GROUP_ID)"

--- a/pipeline/buildpacks/0.2/buildpacks.yaml
+++ b/pipeline/buildpacks/0.2/buildpacks.yaml
@@ -4,10 +4,10 @@ kind: Pipeline
 metadata:
   name: buildpacks
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/categories: Image Build
-    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/pipelines.minVersion: "0.36.0"
     tekton.dev/tags: image-build
     tekton.dev/displayName: "Buildpacks"
     tekton.dev/platforms: "linux/amd64"
@@ -91,20 +91,6 @@ spec:
           value: "$(params.BUILDER_IMAGE)"
         - name: APP_IMAGE
           value: "$(params.APP_IMAGE)"
-        - name: SOURCE_SUBPATH
-          value: "$(params.SOURCE_SUBPATH)"
-        - name: PROCESS_TYPE
-          value: "$(params.PROCESS_TYPE)"
-        - name: ENV_VARS
-          value: ["$(params.ENV_VARS)"]
-        - name: RUN_IMAGE
-          value: "$(params.RUN_IMAGE)"
-        - name: CACHE_IMAGE
-          value: "$(params.CACHE_IMAGE)"
-        - name: USER_ID
-          value: "$(params.USER_ID)"
-        - name: GROUP_ID
-          value: "$(params.GROUP_ID)"
     - name: build-untrusted
       runAfter:
         - fetch-from-git
@@ -124,17 +110,3 @@ spec:
           value: "$(params.BUILDER_IMAGE)"
         - name: APP_IMAGE
           value: "$(params.APP_IMAGE)"
-        - name: SOURCE_SUBPATH
-          value: "$(params.SOURCE_SUBPATH)"
-        - name: ENV_VARS
-          value: ["$(params.ENV_VARS)"]
-        - name: PROCESS_TYPE
-          value: "$(params.PROCESS_TYPE)"
-        - name: RUN_IMAGE
-          value: "$(params.RUN_IMAGE)"
-        - name: CACHE_IMAGE
-          value: "$(params.CACHE_IMAGE)"
-        - name: USER_ID
-          value: "$(params.USER_ID)"
-        - name: GROUP_ID
-          value: "$(params.GROUP_ID)"

--- a/pipeline/buildpacks/0.2/samples/cache-image.yaml
+++ b/pipeline/buildpacks/0.2/samples/cache-image.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cache-image-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: cache-image-pipelinerun
+  labels:
+    app.kubernetes.io/description: A PipelineRun configured to cache build artifacts in an image.
+spec:
+  pipelineRef:
+    name: buildpacks
+  params:
+    - name: BUILDER_IMAGE
+      value: docker.io/cnbs/sample-builder:bionic@sha256:6c03dd604503b59820fd15adbc65c0a077a47e31d404a3dcad190f3179e920b5
+    - name: TRUST_BUILDER
+      value: "true"
+    - name: APP_IMAGE
+      value: <IMAGE_NAME>
+    - name: SOURCE_URL
+      value: https://github.com/buildpacks/samples
+    - name: SOURCE_SUBPATH
+      value: apps/ruby-bundler
+    - name: CACHE_IMAGE
+      value: <IMAGE_NAME>-cache
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: cache-image-ws-pvc
+    # NOTE: Pipeline hangs if optional cache workspace is missing so we provide an empty directory
+    - name: cache-ws
+      emptyDir: {}

--- a/pipeline/buildpacks/0.2/samples/cache-volume.yaml
+++ b/pipeline/buildpacks/0.2/samples/cache-volume.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cache-volume-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: cache-volume-pipelinerun
+  labels:
+    app.kubernetes.io/description: A PipelineRun configured to cache build artifacts in a volume.
+spec:
+  pipelineRef:
+    name: buildpacks
+  params:
+    - name: BUILDER_IMAGE
+      value: docker.io/cnbs/sample-builder:bionic@sha256:6c03dd604503b59820fd15adbc65c0a077a47e31d404a3dcad190f3179e920b5
+    - name: TRUST_BUILDER
+      value: "false"
+    - name: APP_IMAGE
+      value: <IMAGE_NAME>
+    - name: SOURCE_URL
+      value: https://github.com/buildpacks/samples
+    - name: SOURCE_SUBPATH
+      value: apps/ruby-bundler
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: cache-volume-ws-pvc
+    - name: cache-ws
+      subPath: cache
+      persistentVolumeClaim:
+        claimName: cache-volume-ws-pvc

--- a/pipeline/buildpacks/0.2/samples/env-vars.yaml
+++ b/pipeline/buildpacks/0.2/samples/env-vars.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: env-var-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: env-var-pipelinerun
+  labels:
+    app.kubernetes.io/description: A PipelineRun configured to provide _build-time_ environment variables.
+spec:
+  pipelineRef:
+    name: buildpacks
+  params:
+    - name: BUILDER_IMAGE
+      value: docker.io/cnbs/sample-builder:bionic@sha256:6c03dd604503b59820fd15adbc65c0a077a47e31d404a3dcad190f3179e920b5
+    - name: TRUST_BUILDER
+      value: "true"
+    - name: APP_IMAGE
+      value: <IMAGE_NAME>
+    - name: SOURCE_URL
+      value: https://github.com/buildpacks/samples
+    - name: SOURCE_SUBPATH
+      value: apps
+    - name: PROCESS_TYPE
+      value: ""
+    - name: ENV_VARS
+      value:
+        - "ENV_VAR_1=VALUE_1"
+        - "ENV_VAR_2=VALUE 2"
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: env-var-ws-pvc
+    # NOTE: Pipeline hangs if optional cache workspace is missing so we provide an empty directory
+    - name: cache-ws
+      emptyDir: {}

--- a/pipeline/buildpacks/0.2/samples/run-image.yaml
+++ b/pipeline/buildpacks/0.2/samples/run-image.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: run-image-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: run-image-pipelinerun
+  labels:
+    app.kubernetes.io/description: A PipelineRun configured to specify an explicit run image.
+spec:
+  pipelineRef:
+    name: buildpacks
+  params:
+    - name: BUILDER_IMAGE
+      value: docker.io/cnbs/sample-builder:bionic@sha256:6c03dd604503b59820fd15adbc65c0a077a47e31d404a3dcad190f3179e920b5
+    - name: TRUST_BUILDER
+      value: "true"
+    - name: APP_IMAGE
+      value: <IMAGE_NAME>
+    - name: SOURCE_URL
+      value: https://github.com/buildpacks/samples
+    - name: SOURCE_SUBPATH
+      value: apps/ruby-bundler
+    - name: RUN_IMAGE
+      value: docker.io/cnbs/sample-stack-run:bionic@sha256:766617895a96c9cdc58fa604468328f6918a13f5c225fbe267b37df9dce40fda
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: run-image-ws-pvc
+    # NOTE: Pipeline hangs if optional cache workspace is missing so we provide an empty directory
+    - name: cache-ws
+      emptyDir: {}

--- a/pipeline/buildpacks/0.2/tests/pre-apply-task-hook.sh
+++ b/pipeline/buildpacks/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Add an internal registry as sidecar to the task so we can upload it directly
+# from our tests without having to go to an external registry.
+add_sidecar_registry ${TMPF}
+
+# Add dependency tasks
+add_task git-clone latest
+add_task buildpacks latest
+add_task buildpacks-phases latest

--- a/pipeline/buildpacks/0.2/tests/run.yaml
+++ b/pipeline/buildpacks/0.2/tests/run.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: buildpacks-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: buildpacks-pipelinerun
+  labels:
+    app.kubernetes.io/description: A PipelineRun configured to cache build artifacts in a volume.
+spec:
+  pipelineRef:
+    name: buildpacks
+  params:
+    - name: BUILDER_IMAGE
+      value: docker.io/cnbs/sample-builder:bionic@sha256:6c03dd604503b59820fd15adbc65c0a077a47e31d404a3dcad190f3179e920b5
+    - name: TRUST_BUILDER
+      value: "false"
+    - name: APP_IMAGE
+      value: localhost:5000/buildpacks-app
+    - name: SOURCE_URL
+      value: https://github.com/buildpacks/samples
+    - name: SOURCE_SUBPATH
+      value: apps/ruby-bundler
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: buildpacks-ws-pvc
+    - name: cache-ws
+      subPath: cache
+      persistentVolumeClaim:
+        claimName: buildpacks-ws-pvc


### PR DESCRIPTION
Takes advantage of parameter propagation included in Tekton Pipeline v0.36.0 (https://github.com/tektoncd/pipeline/releases/tag/v0.36.0)

Fixes: #36